### PR TITLE
Fixed issue with workspaces that have hyphened name

### DIFF
--- a/notebooks/00_demo_setup.ipynb
+++ b/notebooks/00_demo_setup.ipynb
@@ -517,7 +517,7 @@
     "        \"03_create_ontology\",\n",
     "        timeout_seconds=900,\n",
     "        arguments={\n",
-    "            \"WORKSPACE_NAME\": WORKSPACE_NAME,\n",
+    "            \"WORKSPACE_NAME\": f"`{WORKSPACE_NAME}`",\n",
     "            \"LAKEHOUSE_NAME\": LAKEHOUSE_NAME,\n",
     "        }\n",
     "    )\n",

--- a/notebooks/00_demo_setup.ipynb
+++ b/notebooks/00_demo_setup.ipynb
@@ -517,7 +517,7 @@
     "        \"03_create_ontology\",\n",
     "        timeout_seconds=900,\n",
     "        arguments={\n",
-    "            \"WORKSPACE_NAME\": f"`{WORKSPACE_NAME}`",\n",
+    "            \"WORKSPACE_NAME\": f'`{WORKSPACE_NAME}`',\n",
     "            \"LAKEHOUSE_NAME\": LAKEHOUSE_NAME,\n",
     "        }\n",
     "    )\n",


### PR DESCRIPTION
This failed because my workspace was named Trucking-Ontology. Backticking the name allowed it to work.